### PR TITLE
SemanticKernelのバージョン更新と機能追加

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.17.2" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.18.2" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.18.2" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.16.2-alpha" />
   </ItemGroup>
 

--- a/ConsoleApp16/Program.cs
+++ b/ConsoleApp16/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 IConfigurationRoot config = new ConfigurationBuilder()
@@ -25,23 +26,31 @@ builder.Services.AddSingleton<HttpClient>();
 builder.Plugins.AddFromType<WeatherPlugin>();
 Kernel kernel = builder.Build();
 
+ChatHistory chatHistory = new();
+var chat = kernel.GetRequiredService<IChatCompletionService>();
+
 OpenAIPromptExecutionSettings? setting = new()
 {
     ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
-
+    MaxTokens = 2000,
 };
 
 while (true)
 {
     Console.Write("User > ");
     string input = Console.ReadLine()!;
+
+    chatHistory.AddUserMessage(input);
+
     if (input == "exit")
     {
         break;
     }
     else
     {
-        var result = await kernel.InvokePromptAsync(input, new(setting));
+        //var result = await kernel.InvokePromptAsync(input, new(setting));
+        var result = await chat.GetChatMessageContentAsync(chatHistory, setting, kernel);
+        chatHistory.AddAssistantMessage(result.ToString());
         Console.WriteLine($"Assistant > {result}");
     }
 }

--- a/ConsoleApp16/WeatherPlugin.cs
+++ b/ConsoleApp16/WeatherPlugin.cs
@@ -22,6 +22,9 @@ public class WeatherPlugin(HttpClient client)
         対応している場所コードは下記のとおりです。
         下記に含まれない場所の場合は近くの場所の天気を代わりに取得してください。
         東京
+        群馬
+        埼玉
+        千葉
         横浜
         名古屋
         京都
@@ -40,11 +43,17 @@ public class WeatherPlugin(HttpClient client)
         仙台
         福岡
         那覇
+        ----
+        以上、ここに含まれない場合は近くの場所の代わりに取得してください。
         """)]
     public static int GetPlaceId([Description("天気を取得する場所")] string place)
     {
         var res = place switch
         {
+            "札幌" => 016000,
+            "群馬" => 100000,
+            "埼玉" => 110000,
+            "千葉" => 120000,
             "東京" => 130000,
             "横浜" => 140000,
             "名古屋" => 230000,
@@ -60,7 +69,6 @@ public class WeatherPlugin(HttpClient client)
             "松本" => 200000,
             "大津" => 250000,
             "大阪" => 270000,
-            "札幌" => 016000,
             "仙台" => 040000,
             "福岡" => 400000,
             "那覇" => 471000,


### PR DESCRIPTION
`ConsoleApp16.csproj` ファイルでは、`Microsoft.SemanticKernel` と `Microsoft.SemanticKernel.Core` のバージョンが `1.17.2` から `1.18.2` に更新されました。

`Program.cs` ファイルでは、`Microsoft.SemanticKernel.ChatCompletion` 名前空間が追加され、`ChatHistory` クラスと `IChatCompletionService` が使用されるようになりました。また、`OpenAIPromptExecutionSettings` の `MaxTokens` プロパティが追加されました。`kernel.InvokePromptAsync` メソッドの呼び出しがコメントアウトされ、代わりに `chat.GetChatMessageContentAsync` メソッドが使用されるようになりました。

`WeatherPlugin.cs` ファイルでは、天気を取得する場所コードに「群馬」、「埼玉」、「千葉」が追加されました。また、説明文に「----」と「以上、ここに含まれない場合は近くの場所の代わりに取得してください。」が追加されました。

`WeatherPlugin.cs` ファイルの `GetPlaceId` メソッドでは、「札幌」の場所コードがリストの上部から削除され、下部に移動されました。