### PR TITLE
パッケージのバージョンを更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.18.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.18.2" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.16.2-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.20.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.20.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.20.0-alpha" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft.SemanticKernel パッケージのバージョンが 1.18.2 から 1.20.0 に更新されました。
Microsoft.SemanticKernel.Core パッケージのバージョンが 1.18.2 から 1.20.0 に更新されました。
Microsoft.SemanticKernel.Plugins.Core パッケージのバージョンが 1.16.2-alpha から 1.20.0-alpha に更新されました。

#### PR Classification
パッケージのバージョン更新

#### PR Summary
`Microsoft.SemanticKernel` 関連のパッケージのバージョンが更新されました。
- `Microsoft.SemanticKernel` パッケージのバージョンが `1.18.2` から `1.20.0` に更新
- `Microsoft.SemanticKernel.Core` パッケージのバージョンが `1.18.2` から `1.20.0` に更新
- `Microsoft.SemanticKernel.Plugins.Core` パッケージのバージョンが `1.16.2-alpha` から `1.20.0-alpha` に更新
