### PR TITLE
設定のリファクタリングと警告の無効化

### DIFF
--- a/ConsoleApp16/Program.cs
+++ b/ConsoleApp16/Program.cs
@@ -35,6 +35,13 @@ OpenAIPromptExecutionSettings? setting = new()
     MaxTokens = 2000,
 };
 
+#pragma warning disable SKEXP0001 // 種類は、評価の目的でのみ提供されています。将来の更新で変更または削除されることがあります。続行するには、この診断を非表示にします。
+PromptExecutionSettings promptExecutionSettings = new()
+{
+    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+};
+#pragma warning restore SKEXP0001 // 種類は、評価の目的でのみ提供されています。将来の更新で変更または削除されることがあります。続行するには、この診断を非表示にします。
+
 while (true)
 {
     Console.Write("User > ");
@@ -49,7 +56,7 @@ while (true)
     else
     {
         //var result = await kernel.InvokePromptAsync(input, new(setting));
-        var result = await chat.GetChatMessageContentAsync(chatHistory, setting, kernel);
+        var result = await chat.GetChatMessageContentAsync(chatHistory, promptExecutionSettings, kernel);
         chatHistory.AddAssistantMessage(result.ToString());
         Console.WriteLine($"Assistant > {result}");
     }


### PR DESCRIPTION
`OpenAIPromptExecutionSettings` を `PromptExecutionSettings` に変更しました。また、`PromptExecutionSettings` のインスタンス作成時に `#pragma warning disable SKEXP0001` と `#pragma warning restore SKEXP0001` を追加し、警告を無効にしました。`FunctionChoiceBehavior` プロパティを `FunctionChoiceBehavior.Auto()` に設定し、`while (true)` ループ内で `chat.GetChatMessageContentAsync` メソッドの呼び出しに使用する設定を `setting` から `promptExecutionSettings` に変更しました。

#### PR Classification
コードのクリーンアップ

#### PR Summary
`OpenAIPromptExecutionSettings` と `PromptExecutionSettings` の設定を整理し、警告を無効化するためのプリプロセッサディレクティブを追加しました。
- `OpenAIPromptExecutionSettings` に `#pragma warning disable SKEXP0001` と `#pragma warning restore SKEXP0001` を追加
- `PromptExecutionSettings` を新たに追加し、`FunctionChoiceBehavior` の設定を含む
- `while (true)` 内で `kernel.InvokePromptAsync` のコメントアウトを維持
- `chat.GetChatMessageContentAsync` の呼び出しで `setting` を `promptExecutionSettings` に変更
