### PR TITLE
Azure.Identity パッケージを 1.12.1 に更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />


### PR DESCRIPTION
`ConsoleApp16.csproj` ファイルにおいて、`Azure.Identity` パッケージのバージョンが `1.12.0` から `1.12.1` に更新されました。他のパッケージのバージョンには変更がありません。