### PR TITLE
ターゲットフレームワークとパッケージのバージョン更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>d37131bf-1bb4-49d5-9c1c-daa4e3866e4b</UserSecretsId>
@@ -10,12 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.22.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.22.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.20.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
プロジェクトのターゲットフレームワークが `net8.0` から `net9.0` に変更されました。

`Microsoft.Extensions.Configuration`、`Microsoft.Extensions.Configuration.Abstractions`、および `Microsoft.Extensions.Hosting` のパッケージバージョンが `8.0.0` および `8.0.1` から `9.0.0-rc.2.24473.5` に更新されました。

`Microsoft.SemanticKernel.Plugins.Core` のパッケージバージョンが `1.20.0-alpha` から `1.22.0-alpha` に更新されました。