### PR TITLE
パッケージのバージョン更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.22.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.22.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.24.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.24.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
`Azure.Identity` パッケージのバージョンが `1.12.1` から `1.13.0` に更新されました。
`Microsoft.SemanticKernel` パッケージのバージョンが `1.22.0` から `1.24.0` に更新されました。
`Microsoft.SemanticKernel.Core` パッケージのバージョンが `1.22.0` から `1.24.0` に更新されました。