### PR TITLE
パッケージバージョンの更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.24.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.24.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.24.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.24.1" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
パッケージバージョンの更新

`Microsoft.SemanticKernel` パッケージのバージョンを `1.24.0` から `1.24.1` に更新しました。
`Microsoft.SemanticKernel.Core` パッケージのバージョンを `1.24.0` から `1.24.1` に更新しました。