### PR TITLE
パッケージのバージョンを更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.24.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.24.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.25.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.25.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
パッケージのバージョンを更新

`Azure.Identity`パッケージのバージョンが1.13.0から1.13.1に更新されました。
`Microsoft.SemanticKernel`パッケージのバージョンが1.24.1から1.25.0に更新されました。
`Microsoft.SemanticKernel.Core`パッケージのバージョンが1.24.1から1.25.0に更新されました。