### PR TITLE
入力が "exit" から空または null で終了に変更

### DIFF
--- a/ConsoleApp16/Program.cs
+++ b/ConsoleApp16/Program.cs
@@ -51,7 +51,7 @@ while (true)
 
     chatHistory.AddUserMessage(input);
 
-    if (input == "exit")
+    if (string.IsNullOrEmpty(input))
     {
         break;
     }


### PR DESCRIPTION
入力が "exit" から空または null で終了に変更

ユーザーの入力が "exit" だった場合にループを終了する条件が、
入力が空または null の場合にループを終了する条件に変更されました。