### PR TITLE
パッケージバージョンを1.27.0に更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.26.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.26.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.27.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.27.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
パッケージバージョンを1.27.0に更新

`Microsoft.SemanticKernel`と`Microsoft.SemanticKernel.Core`のパッケージバージョンが1.26.0から1.27.0に更新されました。