### PR TITLE
依存関係のバージョンを更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.27.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.27.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.28.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.28.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
依存関係のバージョンを更新

`Microsoft.Extensions.Configuration`、`Microsoft.Extensions.Configuration.Abstractions`、`Microsoft.Extensions.Hosting`のバージョンを`9.0.0-rc.2.24473.5`から`9.0.0`に更新しました。
`Microsoft.SemanticKernel`と`Microsoft.SemanticKernel.Core`のバージョンを`1.27.0`から`1.28.0`に更新しました。