### PR TITLE
パッケージバージョンの更新

### DIFF
--- a/ConsoleApp16/ConsoleApp16.csproj
+++ b/ConsoleApp16/ConsoleApp16.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.28.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.28.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.29.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.29.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.22.0-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
パッケージバージョンの更新

`Microsoft.SemanticKernel`と`Microsoft.SemanticKernel.Core`のパッケージバージョンが1.28.0から1.29.0に更新されました。